### PR TITLE
Add Spring cloud kubernetes discoveryserver example

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -63,7 +63,7 @@ http://localhost/spring-boot-admin-discoveryclient
 - [./apps/hello-world/README.md](./apps/hello-world/README.md)
 - [./apps/spring-boot-admin-kubernetes/README.md](./apps/spring-boot-admin-kubernetes/README.md)
 - [./apps/spring-boot-admin-fabric8/README.md](./apps/spring-boot-admin-fabric8/README.md)
-- [./apps/spring-boot-admin-discoveryclient/README.md](./apps/spring-boot-admin-fabric8/README.md)
+- [./apps/spring-boot-admin-discoveryclient/README.md](./apps/spring-boot-admin-discoveryclient/README.md)
 - [./apps/health-simulator/README.md](./apps/health-simulator/README.md)
 
 ## Uninstall Everything

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -6,6 +6,9 @@ There are 2 instances of Spring Boot Admin available. Both use the discovery mec
 there is no self registration used. One SBA is using the spring cloud kubernetes-client and the other one
 the spring cloud kubernetes-fabric8. There are small differences in the configuration between these two versions.
 
+There is also a version using the spring cloud kubernetes discovery server to get all running services instead of using
+kubernetes discovery directly.
+
 This Readme will guide you through all setup steps for the infrastructure.
 
 ## Enable Kubernetes in Docker Desktop

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -40,7 +40,7 @@ helm version
 - <https://helm.sh/docs/intro/quickstart/>
 
 ## Install Everything
-You can run the whole build and installation for all apps with the following script or follow the step by step guide below.
+You can run the whole build and installation for all apps with the following script or follow the step-by-step guide below.
 ```bash
 chmod u+x buildAndInstallAll.sh
 ./buildAndInstallAll.sh
@@ -49,6 +49,8 @@ chmod u+x buildAndInstallAll.sh
 http://localhost/spring-boot-admin-kubernetes
 
 http://localhost/spring-boot-admin-fabric8
+
+http://localhost/spring-boot-admin-discoveryclient
 
 ## Step-by-step Installation
 
@@ -61,6 +63,7 @@ http://localhost/spring-boot-admin-fabric8
 - [./apps/hello-world/README.md](./apps/hello-world/README.md)
 - [./apps/spring-boot-admin-kubernetes/README.md](./apps/spring-boot-admin-kubernetes/README.md)
 - [./apps/spring-boot-admin-fabric8/README.md](./apps/spring-boot-admin-fabric8/README.md)
+- [./apps/spring-boot-admin-discoveryclient/README.md](./apps/spring-boot-admin-fabric8/README.md)
 - [./apps/health-simulator/README.md](./apps/health-simulator/README.md)
 
 ## Uninstall Everything

--- a/kubernetes/apps/health-simulator/README.md
+++ b/kubernetes/apps/health-simulator/README.md
@@ -6,7 +6,7 @@ You can change the number of replicas in [deployment/values.yaml](deployment/val
 
 ## Build & Install Script
 
-You can run the whole build and installation with the following script or follow the step by step guide below.
+You can run the whole build and installation with the following script or follow the step-by-step guide below.
 
 ```bash
 chmod u+x buildAndInstall.sh

--- a/kubernetes/apps/hello-world/README.md
+++ b/kubernetes/apps/hello-world/README.md
@@ -2,7 +2,7 @@
 
 ## Build & Install Script
 
-You can run the whole build and installation with the following script or follow the step by step guide below.
+You can run the whole build and installation with the following script or follow the step-by-step guide below.
 
 ```bash
 chmod u+x buildAndInstall.sh

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/.gitignore
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/.gitignore
@@ -1,0 +1,5 @@
+target
+.idea
+*.iml
+*.log
+*.gz

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/Dockerfile
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/Dockerfile
@@ -1,0 +1,8 @@
+# https://hub.docker.com/_/eclipse-temurin/
+FROM eclipse-temurin:17
+
+VOLUME /tmp
+
+COPY target/app.jar /opt/app/app.jar
+
+CMD ["bash", "-c", "java $JAVA_OPTS -jar /opt/app/app.jar"]

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
@@ -6,6 +6,13 @@ For this reason, the SBA server does not need kubernetes api permissions on kube
 spring-boot-app helmchart.
 
 
+TODO does not add new services that are started after this one, seems is no Watch like in the other discovery clients. 
+This also means that it does not add itself to the list of services. 
+
+
+Make sure [discoveryserver](../../helm-charts/spring-cloud-kubernetes-discoveryserver/README.md) is running before deploying this app.
+
+
 ## Build & Install Script
 
 You can run the whole build and installation with the following script or follow the step-by-step guide below.
@@ -32,7 +39,7 @@ We use the standard "app" helm chart here and NOT the "admin" helm chart as we d
 setup. The discoveryserver has the permissions and is providing the apps via rest api.
 
 ```bash
-helm upgrade --install spring-boot-admin-discocli ../../helm-charts/spring-boot-app -f deployment/values.yml
+helm upgrade --install spring-boot-admin-discoveryclient ../../helm-charts/spring-boot-app -f deployment/values.yml
 ```
 
 ### Check deployment
@@ -44,12 +51,12 @@ kubectl get ingress
 
 ### Uninstall
 ```bash
-helm uninstall spring-boot-admin-discocli
+helm uninstall spring-boot-admin-discoveryclient
 ```
 
 ## URI
 
-- http://localhost/spring-boot-admin-discocli (requires [traefik](../../helm-charts/traefik/README.md) to be running)
+- http://localhost/spring-boot-admin-discoveryclient (requires [traefik](../../helm-charts/traefik/README.md) to be running)
 
 ## Access Actuator
 ```bash

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
@@ -1,14 +1,14 @@
 # Spring Boot Admin
 
 This is a Spring Boot Admin instance using spring-cloud-starter-kubernetes-discoveryclient for service discovery.
-Therefore it needs a running spring-cloud-kubernetes-discoveryserver.
+Therefore, it needs a running spring-cloud-kubernetes-discoveryserver.
 For this reason, the SBA server does not need kubernetes api permissions on kubernetes itself and uses the 
 spring-boot-app helmchart.
 
 
 ## Build & Install Script
 
-You can run the whole build and installation with the following script or follow the step by step guide below.
+You can run the whole build and installation with the following script or follow the step-by-step guide below.
 
 ```bash
 chmod u+x buildAndInstall.sh
@@ -56,8 +56,8 @@ helm uninstall spring-boot-admin-discocli
 kubectl get pods
 ```
 ```bash
-kubectl port-forward <pod-name> 9091:9071
+kubectl port-forward <pod-name> 8081:8081
 ```
 ### URI
 
-- http://localhost:9091/actuator
+- http://localhost:8081/actuator

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
@@ -49,7 +49,7 @@ helm uninstall spring-boot-admin-discocli
 
 ## URI
 
-- http://localhost/spring-boot-admin-kubernetes
+- http://localhost/spring-boot-admin-discocli (requires [traefik](../../helm-charts/traefik/README.md) to be running)
 
 ## Access Actuator
 ```bash

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
@@ -28,8 +28,11 @@ docker build --tag spring-boot-admin:discocli .
 ```
 
 ### Install App
+We use the standard "app" helm chart here and NOT the "admin" helm chart as we do not need the k8s api access with this
+setup. The discoveryserver has the permissions and is providing the apps via rest api.
+
 ```bash
-helm upgrade --install spring-boot-admin-discocli ../../helm-charts/spring-boot-admin -f deployment/values.yml
+helm upgrade --install spring-boot-admin-discocli ../../helm-charts/spring-boot-app -f deployment/values.yml
 ```
 
 ### Check deployment
@@ -37,14 +40,11 @@ helm upgrade --install spring-boot-admin-discocli ../../helm-charts/spring-boot-
 kubectl get pods -o wide
 kubectl get services -o wide
 kubectl get ingress
-kubectl get serviceaccount
-kubectl get role
-kubectl get rolebinding -o wide
 ```
-TODO role stuff not needed
+
 ### Uninstall
 ```bash
-helm uninstall spring-boot-admin-kubernetes
+helm uninstall spring-boot-admin-discocli
 ```
 
 ## URI

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/README.md
@@ -1,6 +1,10 @@
 # Spring Boot Admin
 
-This is a Spring Boot Admin instance using spring-cloud-starter-kubernetes-fabric8 for service discovery. 
+This is a Spring Boot Admin instance using spring-cloud-starter-kubernetes-discoveryclient for service discovery.
+Therefore it needs a running spring-cloud-kubernetes-discoveryserver.
+For this reason, the SBA server does not need kubernetes api permissions on kubernetes itself and uses the 
+spring-boot-app helmchart.
+
 
 ## Build & Install Script
 
@@ -20,12 +24,12 @@ mvn clean install
 
 ### Build Docker Image
 ```bash
-docker build --tag spring-boot-admin:fabric8 .
+docker build --tag spring-boot-admin:discocli .
 ```
 
 ### Install App
 ```bash
-helm upgrade --install spring-boot-admin-fabric8 ../../helm-charts/spring-boot-admin -f deployment/values.yml
+helm upgrade --install spring-boot-admin-discocli ../../helm-charts/spring-boot-admin -f deployment/values.yml
 ```
 
 ### Check deployment
@@ -37,22 +41,22 @@ kubectl get serviceaccount
 kubectl get role
 kubectl get rolebinding -o wide
 ```
-
+TODO role stuff not needed
 ### Uninstall
 ```bash
-helm uninstall spring-boot-admin-fabric8
+helm uninstall spring-boot-admin-kubernetes
 ```
 
 ## URI
 
-- http://localhost/spring-boot-admin-fabric8
+- http://localhost/spring-boot-admin-kubernetes
 
 ## Access Actuator
 ```bash
 kubectl get pods
 ```
 ```bash
-kubectl port-forward <pod-name> 9091:8081
+kubectl port-forward <pod-name> 9091:9071
 ```
 ### URI
 

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/WORK IN PROGRESS
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/WORK IN PROGRESS
@@ -1,3 +1,0 @@
-TODO add discoveryserver as container to k8s
-TODO test if this works
-TODO check https://github.com/codecentric/spring-boot-admin/issues/2872

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/WORK IN PROGRESS
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/WORK IN PROGRESS
@@ -1,0 +1,3 @@
+TODO add discoveryserver as container to k8s
+TODO test if this works
+TODO check https://github.com/codecentric/spring-boot-admin/issues/2872

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/buildAndInstall.sh
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/buildAndInstall.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Build App
+mvn clean install
+# Build Docker Image
+docker build --tag spring-boot-admin:discocli .
+# Install App
+helm upgrade --install spring-boot-admin-discocli ../../helm-charts/spring-boot-app -f deployment/values.yml

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/buildAndInstall.sh
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/buildAndInstall.sh
@@ -5,4 +5,4 @@ mvn clean install
 # Build Docker Image
 docker build --tag spring-boot-admin:discocli .
 # Install App
-helm upgrade --install spring-boot-admin-discocli ../../helm-charts/spring-boot-app -f deployment/values.yml
+helm upgrade --install spring-boot-admin-discoveryclient ../../helm-charts/spring-boot-app -f deployment/values.yml

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/deployment/values.yml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/deployment/values.yml
@@ -3,7 +3,7 @@ namespace: default
 
 deployment:
   server:
-    port: 9090
+    port: 8080
   management:
-    port: 9091
+    port: 8081
   image: spring-boot-admin:discocli

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/deployment/values.yml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/deployment/values.yml
@@ -1,4 +1,4 @@
-name: spring-boot-admin-discocli
+name: spring-boot-admin-discoveryclient
 namespace: default
 
 deployment:

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/deployment/values.yml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/deployment/values.yml
@@ -1,0 +1,9 @@
+name: spring-boot-admin-discocli
+namespace: default
+
+deployment:
+  server:
+    port: 9090
+  management:
+    port: 9091
+  image: spring-boot-admin:discocli

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/pom.xml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.1.1</version>
+  </parent>
+
+  <groupId>de.codecentric</groupId>
+  <artifactId>spring-boot-admin-discoveryclient</artifactId>
+  <packaging>jar</packaging>
+  <name>${project.artifactId}</name>
+  <version>1.0.0-SNAPSHOT</version>
+  <description>Spring Boot Admin</description>
+
+  <properties>
+    <java.version>17</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spring-boot-admin.version>3.1.0</spring-boot-admin.version>
+    <spring-cloud.version>2022.0.2</spring-cloud.version>
+  </properties>
+
+  <!-- Kubernetes Discovery -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${spring-cloud.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- Spring Boot Admin -->
+    <dependency>
+      <groupId>de.codecentric</groupId>
+      <artifactId>spring-boot-admin-starter-server</artifactId>
+      <version>${spring-boot-admin.version}</version>
+    </dependency>
+
+    <!-- Kubernetes Discovery -->
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-kubernetes-discoveryclient</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>app</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>repackage</id>
+            <goals>
+              <goal>repackage</goal>
+              <!-- Build-Infos for Info-Actuator -->
+              <goal>build-info</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- GIT-Infos for Info-Actuator -->
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <configuration>
+          <offline>true</offline>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/pom.xml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.1</version>
+    <version>3.2.1</version>
   </parent>
 
   <groupId>de.codecentric</groupId>
@@ -20,8 +20,8 @@
   <properties>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-boot-admin.version>3.1.0</spring-boot-admin.version>
-    <spring-cloud.version>2022.0.2</spring-cloud.version>
+    <spring-boot-admin.version>3.2.0</spring-boot-admin.version>
+    <spring-cloud.version>2023.0.0</spring-cloud.version>
   </properties>
 
   <!-- Kubernetes Discovery -->

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/pom.xml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-boot-admin.version>3.2.0</spring-boot-admin.version>
+    <spring-boot-admin.version>3.2.1-SNAPSHOT</spring-boot-admin.version>
     <spring-cloud.version>2023.0.0</spring-cloud.version>
   </properties>
 

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/java/de/codecentric/springbootadmin/SpringBootAdminApplication.java
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/java/de/codecentric/springbootadmin/SpringBootAdminApplication.java
@@ -1,0 +1,21 @@
+package de.codecentric.springbootadmin;
+
+import de.codecentric.boot.admin.server.config.EnableAdminServer;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.metrics.buffering.BufferingApplicationStartup;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableAdminServer
+//@EnableDiscoveryClient TODO do we need this or is this handled by admin already?
+public class SpringBootAdminApplication {
+
+  public static void main(String... args) {
+    var app = new SpringApplication(SpringBootAdminApplication.class);
+    // Buffering for Startup-Actuator
+    app.setApplicationStartup(new BufferingApplicationStartup(2048));
+    app.run();
+  }
+}

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/java/de/codecentric/springbootadmin/SpringBootAdminApplication.java
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/java/de/codecentric/springbootadmin/SpringBootAdminApplication.java
@@ -9,7 +9,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAdminServer
-//@EnableDiscoveryClient TODO do we need this or is this handled by admin already?
 public class SpringBootAdminApplication {
 
   public static void main(String... args) {

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/java/de/codecentric/springbootadmin/SpringBootAdminApplication.java
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/java/de/codecentric/springbootadmin/SpringBootAdminApplication.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAdminServer
+@EnableScheduling
 public class SpringBootAdminApplication {
 
   public static void main(String... args) {

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/resources/application.yml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/resources/application.yml
@@ -7,23 +7,20 @@ spring:
   boot:
     admin:
       ui:
-        # public-url: ${SPRING_BOOT_ADMIN_UI_PUBLIC_URL:http://localhost:8080}
         title: ${SPRING_BOOT_ADMIN_UI_TITLE:Spring Boot Admin}
         brand: <img src="assets/img/icon-spring-boot-admin.svg"><span>${SPRING_BOOT_ADMIN_UI_TITLE:Spring Boot Admin}</span>
+      discovery: # Filter discovery to tagged services
+        instances-metadata:
+          spring-boot-admin: true # is added as annotation in service.yaml in helm chart
   cloud:
     kubernetes:
       discovery:
-#        metadata:
-#          ports:
-#            management: 9091
-#        serviceLabels:
-#          spring-boot: true
         all-namespaces: true
         include-not-ready-addresses: true
         discovery-server-url: "http://spring-cloud-kubernetes-discoveryserver"
 # for local development (starting directly from IDE), enable port forwarding for discovery server and use the following
 # three lines instead of the one above
-#        discovery-server-url: "localhost:8761"
+#        discovery-server-url: "http://localhost:8761"
 #  main:
 #    cloud-platform: KUBERNETES
 management: # Actuator Configuration

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/resources/application.yml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/resources/application.yml
@@ -1,0 +1,67 @@
+server:
+  port: 9090
+spring:
+  application: # Application-Infos for the Info-Actuator
+    name: "@pom.artifactId@"
+  # Spring Boot Admin
+  boot:
+    admin:
+      ui:
+        # public-url: ${SPRING_BOOT_ADMIN_UI_PUBLIC_URL:http://localhost:8080}
+        title: ${SPRING_BOOT_ADMIN_UI_TITLE:Spring Boot Admin}
+        brand: <img src="assets/img/icon-spring-boot-admin.svg"><span>${SPRING_BOOT_ADMIN_UI_TITLE:Spring Boot Admin}</span>
+  cloud:
+    kubernetes:
+      discovery:
+#        metadata:
+#          ports:
+#            management: 9091
+#        serviceLabels:
+#          spring-boot: true
+# TODO how does it find the discovery server?
+        all-namespaces: true
+        include-not-ready-addresses: true
+
+management: # Actuator Configuration
+  server:
+    port: 9091
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint: # Health-Actuator
+    health:
+      show-details: always
+      probes:
+        enabled: true
+    env: # Environment-Actuator
+      show-values: always
+    configprops: # Configuration-Actuator
+      show-values: always
+  info: # Info-Actuator
+    java:
+      enabled: true
+    os:
+      enabled: true
+    build:
+      enabled: true
+    env:
+      enabled: true
+    git:
+      enabled: true
+info: # Application-Infos for the Info-Actuator
+  group: "@pom.groupId@"
+  artifact: "@pom.artifactId@"
+  description: "@pom.description@"
+  version: "@pom.version@"
+  spring-boot: "@pom.parent.version@"
+  spring-boot-admin: "@spring-boot-admin.version@"
+  spring-cloud: "@spring-cloud.version@"
+  # Tags for the Spring Boot Admin UI
+  tags:
+    spring-boot: "@pom.parent.version@"
+    spring-boot-admin: "@spring-boot-admin.version@"
+    spring-cloud: "@spring-cloud.version@"
+logging: # Logging-File for the Logfile-Actuator
+  file:
+    name: "spring-boot-admin.log"

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/resources/application.yml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 9090
+  port: 8080
 spring:
   application: # Application-Infos for the Info-Actuator
     name: "@pom.artifactId@"
@@ -20,7 +20,7 @@ spring:
 #          spring-boot: true
         all-namespaces: true
         include-not-ready-addresses: true
-        discovery-server-url: "spring-cloud-kubernetes-discoveryserver:8761"
+        discovery-server-url: "http://spring-cloud-kubernetes-discoveryserver"
 # for local development (starting directly from IDE), enable port forwarding for discovery server and use the following
 # three lines instead of the one above
 #        discovery-server-url: "localhost:8761"
@@ -28,7 +28,7 @@ spring:
 #    cloud-platform: KUBERNETES
 management: # Actuator Configuration
   server:
-    port: 9091
+    port: 8081
   endpoints:
     web:
       exposure:

--- a/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/resources/application.yml
+++ b/kubernetes/apps/spring-boot-admin-discoveryclient/src/main/resources/application.yml
@@ -18,10 +18,14 @@ spring:
 #            management: 9091
 #        serviceLabels:
 #          spring-boot: true
-# TODO how does it find the discovery server?
         all-namespaces: true
         include-not-ready-addresses: true
-
+        discovery-server-url: "spring-cloud-kubernetes-discoveryserver:8761"
+# for local development (starting directly from IDE), enable port forwarding for discovery server and use the following
+# three lines instead of the one above
+#        discovery-server-url: "localhost:8761"
+#  main:
+#    cloud-platform: KUBERNETES
 management: # Actuator Configuration
   server:
     port: 9091

--- a/kubernetes/apps/spring-boot-admin-fabric8/README.md
+++ b/kubernetes/apps/spring-boot-admin-fabric8/README.md
@@ -45,7 +45,7 @@ helm uninstall spring-boot-admin-fabric8
 
 ## URI
 
-- http://localhost/spring-boot-admin-fabric8
+- http://localhost/spring-boot-admin-fabric8 (requires [traefik](../../helm-charts/traefik/README.md) to be running)
 
 ## Access Actuator
 ```bash

--- a/kubernetes/apps/spring-boot-admin-fabric8/README.md
+++ b/kubernetes/apps/spring-boot-admin-fabric8/README.md
@@ -4,7 +4,7 @@ This is a Spring Boot Admin instance using spring-cloud-starter-kubernetes-fabri
 
 ## Build & Install Script
 
-You can run the whole build and installation with the following script or follow the step by step guide below.
+You can run the whole build and installation with the following script or follow the step-by-step guide below.
 
 ```bash
 chmod u+x buildAndInstall.sh

--- a/kubernetes/apps/spring-boot-admin-fabric8/src/main/resources/application.yml
+++ b/kubernetes/apps/spring-boot-admin-fabric8/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         brand: <img src="assets/img/icon-spring-boot-admin.svg"><span>${SPRING_BOOT_ADMIN_UI_TITLE:Spring Boot Admin}</span>
       discovery: # Filter discovery to tagged services
         instances-metadata:
-          spring-boot-admin: true
+          spring-boot-admin: true # is added as annotation in service.yaml in helm chart
 
 management: # Actuator Configuration
   server:

--- a/kubernetes/apps/spring-boot-admin-kubernetes/README.md
+++ b/kubernetes/apps/spring-boot-admin-kubernetes/README.md
@@ -1,5 +1,7 @@
 # Spring Boot Admin
 
+This is a Spring Boot Admin instance using spring-cloud-starter-kubernetes-client for service discovery.
+
 ## Build & Install Script
 
 You can run the whole build and installation with the following script or follow the step by step guide below.

--- a/kubernetes/apps/spring-boot-admin-kubernetes/README.md
+++ b/kubernetes/apps/spring-boot-admin-kubernetes/README.md
@@ -4,7 +4,7 @@ This is a Spring Boot Admin instance using spring-cloud-starter-kubernetes-clien
 
 ## Build & Install Script
 
-You can run the whole build and installation with the following script or follow the step by step guide below.
+You can run the whole build and installation with the following script or follow the step-by-step guide below.
 
 ```bash
 chmod u+x buildAndInstall.sh

--- a/kubernetes/apps/spring-boot-admin-kubernetes/README.md
+++ b/kubernetes/apps/spring-boot-admin-kubernetes/README.md
@@ -45,7 +45,7 @@ helm uninstall spring-boot-admin-kubernetes
 
 ## URI
 
-- http://localhost/spring-boot-admin-kubernetes
+- http://localhost/spring-boot-admin-kubernetes (requires [traefik](../../helm-charts/traefik/README.md) to be running)
 
 ## Access Actuator
 ```bash

--- a/kubernetes/buildAndInstallAll.sh
+++ b/kubernetes/buildAndInstallAll.sh
@@ -10,6 +10,12 @@ cd apps/spring-boot-admin-fabric8
 ./buildAndInstall.sh
 cd ../..
 
+helm upgrade --install spring-cloud-kubernetes-discoveryserver helm-charts/spring-cloud-kubernetes-discoveryserver
+
+cd apps/spring-boot-admin-discoveryclient
+./buildAndInstall.sh
+cd ../..
+
 cd apps/hello-world
 ./buildAndInstall.sh
 cd ../..

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/Chart.yaml
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Spring Cloud Kubernetes Discovery Server
+name: spring-cloud-kubernetes-discoveryserver
+version: 0.0.0

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/README.md
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/README.md
@@ -1,0 +1,36 @@
+# Spring Cloud Kubernetes Discovery Server
+
+## Documentation
+
+https://docs.spring.io/spring-cloud-kubernetes/reference/spring-cloud-kubernetes-discoveryserver.html
+
+## Install Spring Cloud Kubernetes Discovery Server
+```bash
+helm upgrade --install spring-cloud-kubernetes-discoveryserver .
+```
+
+### Check deployment
+```bash
+kubectl get pods -o wide
+kubectl get services -o wide
+kubectl get serviceaccounts
+kubectl get role
+kubectl get rolebinding -o wide
+```
+
+### Uninstall
+```bash
+helm uninstall spring-cloud-kubernetes-discoveryserver
+```
+
+## Access Actuator
+```bash
+kubectl get pods
+```
+```bash
+kubectl port-forward <pod-name> 8761:8761
+```
+### URI
+
+- http://localhost:8761/apps
+- http://localhost:8761/actuator

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/README.md
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/README.md
@@ -28,7 +28,7 @@ helm uninstall spring-cloud-kubernetes-discoveryserver
 kubectl get pods
 ```
 ```bash
-kubectl port-forward <pod-name> 8761:8761
+kubectl port-forward service/spring-cloud-kubernetes-discoveryserver 8761:80
 ```
 ### URI
 

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/TODO
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/TODO
@@ -1,2 +1,0 @@
-TODO
-see https://docs.spring.io/spring-cloud-kubernetes/reference/spring-cloud-kubernetes-discoveryserver.html#_deployment_yaml

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/TODO
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/TODO
@@ -1,0 +1,2 @@
+TODO
+see https://docs.spring.io/spring-cloud-kubernetes/reference/spring-cloud-kubernetes-discoveryserver.html#_deployment_yaml

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/account.yaml
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: spring-cloud-kubernetes-discoveryserver
+  name: spring-cloud-kubernetes-discoveryserver

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/deployment.yaml
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  strategy:
+    type: {{ .Values.deployment.updateStrategy }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.deployment.maxUnavailable }}
+      maxSurge: {{ .Values.deployment.maxSurge }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+    spec:
+      serviceAccountName: spring-cloud-kubernetes-discoveryserver
+      restartPolicy: {{ .Values.deployment.restartPolicy }}
+      containers:
+      - name: {{ .Values.name }}
+        image: {{ .Values.deployment.image }}
+        imagePullPolicy: {{ .Values.deployment.pullPolicy }}
+        env:
+        {{- with .Values.deployment.env }}
+        {{- range $env_var, $key := . }}
+          - name: {{ $env_var }}
+            value: "{{ $key }}"
+        {{- end }}
+        {{- end }}
+        ports:
+        - containerPort: 8761
+          name: http
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /actuator/health/liveness
+            port: 8761
+          initialDelaySeconds: {{ .Values.deployment.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.deployment.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: /actuator/health/readiness
+            port: 8761
+          initialDelaySeconds: {{ .Values.deployment.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.deployment.readinessProbe.timeoutSeconds }}

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/role-binding.yaml
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/role-binding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    app: spring-cloud-kubernetes-discoveryserver
+  name: spring-cloud-kubernetes-discoveryserver:view
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: namespace-reader
+subjects:
+  - kind: ServiceAccount
+    name: spring-cloud-kubernetes-discoveryserver

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/role.yaml
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/role.yaml
@@ -1,0 +1,10 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: namespace-reader
+
+rules:
+  - apiGroups: ["", "extensions", "apps"]
+    resources: ["services", "endpoints"]
+    verbs: ["get", "list", "watch"]

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/service.yaml
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      # Name must be http or https
+      # Alternative: configure spring.cloud.kubernetes.discovery.primary-port-name
+      name: http
+  selector:
+    app: {{ .Values.name }}

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/values.yaml
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/values.yaml
@@ -1,0 +1,17 @@
+name: spring-cloud-kubernetes-discoveryserver
+namespace: default
+
+deployment:
+  image: springcloud/spring-cloud-kubernetes-discoveryserver:3.0.0-SNAPSHOT
+  pullPolicy: IfNotPresent
+  updateStrategy: RollingUpdate
+  maxSurge: 100%
+  maxUnavailable: 0%
+  replicas: 1
+  restartPolicy: Always
+  livenessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 10

--- a/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/values.yaml
+++ b/kubernetes/helm-charts/spring-cloud-kubernetes-discoveryserver/values.yaml
@@ -2,7 +2,7 @@ name: spring-cloud-kubernetes-discoveryserver
 namespace: default
 
 deployment:
-  image: springcloud/spring-cloud-kubernetes-discoveryserver:3.0.0-SNAPSHOT
+  image: springcloud/spring-cloud-kubernetes-discoveryserver:3.1.0
   pullPolicy: IfNotPresent
   updateStrategy: RollingUpdate
   maxSurge: 100%

--- a/kubernetes/uninstall.sh
+++ b/kubernetes/uninstall.sh
@@ -3,6 +3,7 @@
 helm uninstall hello-world
 helm uninstall spring-boot-admin-fabric8
 helm uninstall spring-boot-admin-kubernetes
+helm uninstall spring-boot-admin-discoveryclient
 helm uninstall health-simulator
 helm uninstall traefik
 helm uninstall spring-cloud-kubernetes-discoveryserver

--- a/kubernetes/uninstall.sh
+++ b/kubernetes/uninstall.sh
@@ -5,3 +5,4 @@ helm uninstall spring-boot-admin-fabric8
 helm uninstall spring-boot-admin-kubernetes
 helm uninstall health-simulator
 helm uninstall traefik
+helm uninstall spring-cloud-kubernetes-discoveryserver


### PR DESCRIPTION
Playground setup with spring-cloud-kubernetes-discoveryserver. 

Can now be used to analyze https://github.com/codecentric/spring-boot-admin/issues/2872

Open issues: 
- SBA cannot handle different management port as discoveryserver provides this as "port.management" instead of "management.port" -> https://github.com/codecentric/spring-boot-admin/pull/3034
- Does discovery on start but is not updating afterwards. Seems there is no "watch" like in other kubernetes clients
- Not yet tested with reactive stuff, just wanted to get a basic setup running. I had the errormessage of the linked issue for a moment during development, but then it was gone, probably due to dependency updates. Will investigate this next.
